### PR TITLE
S1 t2 feature/player - Directional Melee Attack Implementation

### DIFF
--- a/source/core/src/main/com/deco2800/game/components/player/PlayerActions.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerActions.java
@@ -163,7 +163,7 @@ public class PlayerActions extends Component {
   void attack() {
     Sound attackSound = ServiceLocator.getResourceService().getAsset("sounds/Impact4.ogg", Sound.class);
     attackSound.play();
-    playerMeleeAttackComponent.meleeAttackClicked(true);
+    //playerMeleeAttackComponent.meleeAttackClicked(true);
   }
 
   /**

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -1,5 +1,6 @@
 package com.deco2800.game.components.player;
 
+import com.badlogic.gdx.graphics.g3d.environment.DirectionalLight;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.*;
 import com.deco2800.game.components.CombatStatsComponent;
@@ -12,6 +13,7 @@ import com.deco2800.game.physics.PhysicsLayer;
 import com.deco2800.game.physics.components.PhysicsComponent;
 import com.deco2800.game.physics.components.PhysicsComponent.AlignX;
 import com.deco2800.game.physics.components.PhysicsComponent.AlignY;
+import com.deco2800.game.utils.math.Vector2Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +34,12 @@ public class PlayerMeleeAttackComponent extends Component {
     private PlayerCombatStatsComponent playerCombatStats;
     private boolean meleeAttackClicked;
     private boolean closeToAttack;
-    private Vector2 direction;
+    private Vector2 directionMove;
     short targetLayer = PhysicsLayer.NPC;
 
     public PlayerMeleeAttackComponent() {
         fixtureDef = new FixtureDef();
+
     }
 
     @Override
@@ -54,30 +57,37 @@ public class PlayerMeleeAttackComponent extends Component {
 
 
     private void Attack() {
-
+        System.out.println(getDirection());
         dispose();
-        if (fixtureDef.shape == null ) {
+
+        if (fixtureDef.shape == null) {
             logger.trace("{} Setting default bounding box", this);
             fixtureDef.shape = makeBoundingBox();
         }
-        this.meleeAttackClicked = true;
 
+        this.meleeAttackClicked = true;
         Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
         fixture = physBody.createFixture(fixtureDef);
 
         // if sensor is false, NPC will not be able to collide with player's fixture
         setSensor(true);
 
-
     }
 
 
 
     private void Walk(Vector2 walkDirection) {
-        dispose();
-        direction = walkDirection;
-        System.out.println(direction);
+        setDirection(walkDirection);
+        System.out.println(getDirection());
+    }
 
+    private Vector2 getDirection() {
+        return directionMove;
+    }
+
+    private void setDirection(Vector2 direction) {
+        System.out.println("changed");
+        this.directionMove = direction;
 
     }
 
@@ -105,8 +115,6 @@ public class PlayerMeleeAttackComponent extends Component {
      *              with
      */
     private void onEnemyClose(Fixture me, Fixture other) {
-        System.out.println("impact");
-
 
         // By default, should only try detect NPC layers only
         if (!PhysicsLayer.contains(targetLayer, other.getFilterData().categoryBits)) {
@@ -264,6 +272,8 @@ public class PlayerMeleeAttackComponent extends Component {
         if (physBody.getFixtureList().contains(fixture, true)) {
             physBody.destroyFixture(fixture);
         }
+
+        fixtureDef.shape = null;
     }
 
     /**
@@ -272,15 +282,22 @@ public class PlayerMeleeAttackComponent extends Component {
      * @return enlarge fixture and places it on the center of the entity
      */
     private Shape makeBoundingBox() {
+        //System.out.println(directionMove);
         PolygonShape bbox = new PolygonShape();
         Vector2 center = entity.getScale().scl(0.5f);
         // width and height enlarge - this is the range of melee attack for player
-        System.out.println("works");
-        //if (direction  == new Vector2(1,0)) {
-            System.out.println("works");
-            bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)0.69), 0f);
 
+
+
+        //if (direction == Vector2Utils.UP){
+            System.out.println("UP");
+            bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)0.7), 0f);
+            //bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)-0.7), 0f);
+            //bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
+            //bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
         //}
+
+
 
         return bbox;
     }

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -161,7 +161,6 @@ public class PlayerMeleeAttackComponent extends Component {
                 position.y = entity.getScale().y - (size.y / 2);
                 break;
         }
-
         return setAsBox(size, position);
     }
 

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -56,6 +56,9 @@ public class PlayerMeleeAttackComponent extends Component {
     }
 
 
+    /**
+     * Triggered when the player presses the attack button.
+     */
     private void Attack() {
         System.out.println(getDirection());
         dispose();
@@ -74,15 +77,31 @@ public class PlayerMeleeAttackComponent extends Component {
 
     }
 
+    /**
+     * Triggered when the player walks in a direction.
+     *
+     * @param walkDirection direction that the player walked
+     */
     private void Walk(Vector2 walkDirection) {
+        dispose();
         setDirection(walkDirection);
         System.out.println(getDirection());
     }
 
+    /**
+     * Getter for direction of player movement.
+     *
+     * @return player last walked direction
+     */
     private Vector2 getDirection() {
         return directionMove;
     }
 
+    /**
+     * Setter for direction of player movement.
+     *
+     * @param direction the direction that the player last walked in.
+     */
     private void setDirection(Vector2 direction) {
         System.out.println("changed");
         this.directionMove = direction.cpy();

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -56,35 +56,16 @@ public class PlayerMeleeAttackComponent extends Component {
 
     }
 
-
-    /**
-     * Triggered when the player presses the attack button.
-     */
-    private void Attack() {
-        System.out.println(getDirection());
-        dispose();
-
-        if (fixtureDef.shape == null) {
-            logger.trace("{} Setting default bounding box", this);
-            fixtureDef.shape = makeBoundingBox();
-        }
-
-        this.meleeAttackClicked = true;
-        Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
-        fixture = physBody.createFixture(fixtureDef);
-
-        // if sensor is false, NPC will not be able to collide with player's fixture
-        setSensor(true);
-        System.out.println("FIXTURE CREATED : " + fixture);
-    }
-
     /**
      * Triggered when the player walks in a direction.
      *
      * @param walkDirection direction that the player walked
      */
     private void Walk(Vector2 walkDirection) {
-        dispose();
+
+        if (fixture != null) {
+            dispose();
+        }
         setDirection(walkDirection);
         System.out.println("FIXTURE NO MORE " + fixture);
     }
@@ -129,7 +110,7 @@ public class PlayerMeleeAttackComponent extends Component {
      *              with
      */
     private void onEnemyClose(Fixture me, Fixture other) {
-        System.out.println("enemy coliding");
+        logger.info("ENEMY COLLIDING");
         System.out.println(me);
         System.out.println("different fixture : " + fixture);
 
@@ -157,6 +138,40 @@ public class PlayerMeleeAttackComponent extends Component {
             }
 
             this.meleeAttackClicked = false;
+        }
+    }
+
+    /**
+     * Triggered when the player presses the attack button.
+     */
+    private void Attack() {
+        System.out.println(getDirection());
+        dispose();
+
+        if (fixtureDef.shape == null) {
+            logger.trace("{} Setting default bounding box", this);
+            fixtureDef.shape = makeBoundingBox();
+        }
+
+        this.meleeAttackClicked = true;
+        Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
+        fixture = physBody.createFixture(fixtureDef);
+
+        // if sensor is false, NPC will not be able to collide with player's fixture
+        setSensor(true);
+        System.out.println("FIXTURE CREATED : " + fixture);
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        logger.info("Destroy fixture now =====");
+        System.out.println(fixture);
+        Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
+        if (physBody.getFixtureList().contains(fixture, true) && fixture != null) {
+
+            int toDestroy = physBody.getFixtureList().indexOf(fixture, true);
+            physBody.getFixtureList().removeIndex(toDestroy);
         }
     }
 
@@ -278,32 +293,6 @@ public class PlayerMeleeAttackComponent extends Component {
         return fixture.getFilterData().categoryBits;
     }
 
-    @Override
-    public void dispose() {
-        super.dispose();
-        System.out.println("Destroy fixture now =====");
-        System.out.println(fixture);
-//        System.out.println(fixture.getUserData());
-        Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
-        System.out.println("SOMETHING HEREEEEE" + physBody.getFixtureList().size);
-        if (physBody.getFixtureList().contains(fixture, true)) {
-//            System.out.println("FIXTURE BEING DESTROYEEEEEEEEEEEEED");
-//            physBody.destroyFixture(fixture);
-
-            int toDestroy = physBody.getFixtureList().indexOf(fixture, true);
-            physBody.getFixtureList().removeIndex(toDestroy);
-            System.out.println("INDEX TO DESTROY : " + toDestroy);
-            System.out.println("fixture to destroy " + toDestroy);
-//            physBody.destroyFixture(toDestroy);
-        }
-        System.out.println("SOMETHING HEREEEEE??????" + physBody.getFixtureList().size);
-
-        System.out.println("NULL HERE PLEASE");
-        System.out.println(fixture);
-//        System.out.println(fixture.getShape());
-        fixtureDef.shape = null;
-    }
-
     /**
      * Enlarge shape of fixture based on fixture size of entity
      *
@@ -314,9 +303,6 @@ public class PlayerMeleeAttackComponent extends Component {
         PolygonShape bbox = new PolygonShape();
         Vector2 center = entity.getScale().scl(0.5f);
         // width and height enlarge - this is the range of melee attack for player
-        System.out.println("Saved"+ directionMove);
-        System.out.println("Current" + Vector2Utils.UP);
-
 
         if (directionMove.epsilonEquals(Vector2Utils.UP)){
             System.out.println("UP");

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -330,6 +330,7 @@ public class PlayerMeleeAttackComponent extends Component {
 
 
         return bbox;
+
     }
 
 

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -192,6 +192,7 @@ public class PlayerMeleeAttackComponent extends Component {
         } else {
             fixture.setSensor(isSensor);
         }
+
         return this;
     }
 

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -16,9 +16,6 @@ import com.deco2800.game.physics.components.PhysicsComponent.AlignY;
 import com.deco2800.game.utils.math.Vector2Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -108,8 +105,8 @@ public class PlayerMeleeAttackComponent extends Component {
     /**
      * Called when collision with any fixture has occurred and sets closeToAttack
      * to be True. Event system will continuously check collision between objects in world
-     * If enemy is close and player has clicked the attack melee button, damage will be dealt to
-     * the NPC
+     * If enemy is close and player has clicked the attack melee button, player
+     * will be allowed to damage them.
      *
      * @param me is the fixture of current component
      * @param other is the other fixture which current component is in contact
@@ -132,6 +129,13 @@ public class PlayerMeleeAttackComponent extends Component {
         }
     }
 
+    /**
+     * Function to handle actually hitting an enemy. Gets called after the melee
+     * attack has been triggered and the collision and fixtures are set.
+     *
+     * Goes through each enemy close to the player and damages them individually.
+     * Afterwards, goes through the set of killed enemies and removes them.
+     */
     private void damage() {
         for (Fixture enemy: closeEnemies) {
             Entity target = ((BodyUserData) enemy.getBody().getUserData()).entity;
@@ -153,7 +157,8 @@ public class PlayerMeleeAttackComponent extends Component {
         removingEnemies.clear();
     }
     /**
-     * Triggered when the player presses the attack button.
+     * Triggered when the player presses the attack button. Handles creating
+     * the fixtures for the attack and prepping before actual the damage/hit.
      */
     private void Attack() {
         if (fixtureDef.shape == null) {

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -74,8 +74,6 @@ public class PlayerMeleeAttackComponent extends Component {
 
     }
 
-
-
     private void Walk(Vector2 walkDirection) {
         setDirection(walkDirection);
         System.out.println(getDirection());
@@ -87,7 +85,7 @@ public class PlayerMeleeAttackComponent extends Component {
 
     private void setDirection(Vector2 direction) {
         System.out.println("changed");
-        this.directionMove = direction;
+        this.directionMove = direction.cpy();
 
     }
 
@@ -282,20 +280,33 @@ public class PlayerMeleeAttackComponent extends Component {
      * @return enlarge fixture and places it on the center of the entity
      */
     private Shape makeBoundingBox() {
-        //System.out.println(directionMove);
+
         PolygonShape bbox = new PolygonShape();
         Vector2 center = entity.getScale().scl(0.5f);
         // width and height enlarge - this is the range of melee attack for player
+        System.out.println("Saved"+ directionMove);
+        System.out.println("Current" + Vector2Utils.UP);
 
 
-
-        //if (direction == Vector2Utils.UP){
+        if (directionMove.epsilonEquals(Vector2Utils.UP)){
             System.out.println("UP");
             bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)0.7), 0f);
-            //bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)-0.7), 0f);
-            //bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
-            //bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
-        //}
+        }
+
+        else if (directionMove.epsilonEquals(Vector2Utils.DOWN)){
+            System.out.println("UP");
+            bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)-0.7), 0f);
+        }
+
+        else if (directionMove.epsilonEquals(Vector2Utils.LEFT)){
+            System.out.println("UP");
+            bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
+        }
+
+        else if (directionMove.epsilonEquals(Vector2Utils.RIGHT)){
+            System.out.println("UP");
+            bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float) 0.7 , 0), 0f);
+        }
 
 
 

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -32,6 +32,7 @@ public class PlayerMeleeAttackComponent extends Component {
     private PlayerCombatStatsComponent playerCombatStats;
     private boolean meleeAttackClicked;
     private boolean closeToAttack;
+    private Vector2 direction;
     short targetLayer = PhysicsLayer.NPC;
 
     public PlayerMeleeAttackComponent() {
@@ -40,10 +41,26 @@ public class PlayerMeleeAttackComponent extends Component {
 
     @Override
     public void create() {
-        if (fixtureDef.shape == null) {
+
+        // event listeners to check if enemy is within range of melee attack or not
+        entity.getEvents().addListener("collisionStart", this::onEnemyClose);
+        entity.getEvents().addListener("collisionEnd", this::onEnemyFar);
+        entity.getEvents().addListener("attack", this::Attack);
+        entity.getEvents().addListener("walk", this::Walk);
+
+        playerCombatStats = entity.getComponent(PlayerCombatStatsComponent.class);
+
+    }
+
+
+    private void Attack() {
+
+        dispose();
+        if (fixtureDef.shape == null ) {
             logger.trace("{} Setting default bounding box", this);
             fixtureDef.shape = makeBoundingBox();
         }
+        this.meleeAttackClicked = true;
 
         Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
         fixture = physBody.createFixture(fixtureDef);
@@ -51,13 +68,22 @@ public class PlayerMeleeAttackComponent extends Component {
         // if sensor is false, NPC will not be able to collide with player's fixture
         setSensor(true);
 
-        // event listeners to check if enemy is within range of melee attack or not
-        entity.getEvents().addListener("collisionStart", this::onEnemyClose);
-        entity.getEvents().addListener("collisionEnd", this::onEnemyFar);
 
-
-        playerCombatStats = entity.getComponent(PlayerCombatStatsComponent.class);
     }
+
+
+
+    private void Walk(Vector2 walkDirection) {
+        dispose();
+        direction = walkDirection;
+        System.out.println(direction);
+
+
+    }
+
+
+
+
 
     /**
      * When player and enemy no longer in contact, reset variable closeToAttack. Only resets closeToAttack
@@ -79,6 +105,8 @@ public class PlayerMeleeAttackComponent extends Component {
      *              with
      */
     private void onEnemyClose(Fixture me, Fixture other) {
+        System.out.println("impact");
+
 
         // By default, should only try detect NPC layers only
         if (!PhysicsLayer.contains(targetLayer, other.getFilterData().categoryBits)) {
@@ -96,6 +124,9 @@ public class PlayerMeleeAttackComponent extends Component {
         // enemy within range and player clicked melee attack button
         if (closeToAttack && meleeAttackClicked && targetStats != null) {
             targetStats.hit(playerCombatStats);
+            System.out.println("Enemy Hit");
+            System.out.println(me);
+
 
             // freezes enemy - will need to be replaced to despawn enemy entity
             if (targetStats.isDead()) {
@@ -225,6 +256,7 @@ public class PlayerMeleeAttackComponent extends Component {
         return fixture.getFilterData().categoryBits;
     }
 
+
     @Override
     public void dispose() {
         super.dispose();
@@ -243,7 +275,22 @@ public class PlayerMeleeAttackComponent extends Component {
         PolygonShape bbox = new PolygonShape();
         Vector2 center = entity.getScale().scl(0.5f);
         // width and height enlarge - this is the range of melee attack for player
-        bbox.setAsBox(center.x * 2, center.y * 2, center, 0f);
+        System.out.println("works");
+        //if (direction  == new Vector2(1,0)) {
+            System.out.println("works");
+            bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)0.69), 0f);
+
+        //}
+
         return bbox;
     }
+
+
+
+
+
+
+
+
+
 }

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -67,6 +67,7 @@ public class PlayerMeleeAttackComponent extends Component {
             dispose();
         }
         setDirection(walkDirection);
+        System.out.println(getDirection());
         System.out.println("FIXTURE NO MORE " + fixture);
     }
 
@@ -145,8 +146,10 @@ public class PlayerMeleeAttackComponent extends Component {
      * Triggered when the player presses the attack button.
      */
     private void Attack() {
-        System.out.println(getDirection());
-        dispose();
+
+        if (fixture != null) {
+            dispose();
+        }
 
         if (fixtureDef.shape == null) {
             logger.trace("{} Setting default bounding box", this);
@@ -166,13 +169,13 @@ public class PlayerMeleeAttackComponent extends Component {
     public void dispose() {
         super.dispose();
         logger.info("Destroy fixture now =====");
-        System.out.println(fixture);
         Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
         if (physBody.getFixtureList().contains(fixture, true) && fixture != null) {
 
             int toDestroy = physBody.getFixtureList().indexOf(fixture, true);
             physBody.getFixtureList().removeIndex(toDestroy);
         }
+        fixtureDef.shape = null;
     }
 
     /**
@@ -300,27 +303,27 @@ public class PlayerMeleeAttackComponent extends Component {
      */
     private Shape makeBoundingBox() {
 
+
         PolygonShape bbox = new PolygonShape();
         Vector2 center = entity.getScale().scl(0.5f);
         // width and height enlarge - this is the range of melee attack for player
-
         if (directionMove.epsilonEquals(Vector2Utils.UP)){
-            System.out.println("UP");
+            //System.out.println("UP");
             bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)0.7), 0f);
         }
 
         else if (directionMove.epsilonEquals(Vector2Utils.DOWN)){
-            System.out.println("DOWN");
+            //System.out.println("DOWN");
             bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)-0.7), 0f);
         }
 
         else if (directionMove.epsilonEquals(Vector2Utils.LEFT)){
-            System.out.println("LEFT");
+            //System.out.println("LEFT");
             bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
         }
 
         else if (directionMove.epsilonEquals(Vector2Utils.RIGHT)){
-            System.out.println("RIGHT");
+            //System.out.println("RIGHT");
             bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float) 0.7 , 0), 0f);
         }
 

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -75,7 +75,7 @@ public class PlayerMeleeAttackComponent extends Component {
 
         // if sensor is false, NPC will not be able to collide with player's fixture
         setSensor(true);
-
+        System.out.println("FIXTURE CREATED : " + fixture);
     }
 
     /**
@@ -86,7 +86,7 @@ public class PlayerMeleeAttackComponent extends Component {
     private void Walk(Vector2 walkDirection) {
         dispose();
         setDirection(walkDirection);
-        System.out.println(getDirection());
+        System.out.println("FIXTURE NO MORE " + fixture);
     }
 
     /**
@@ -104,13 +104,9 @@ public class PlayerMeleeAttackComponent extends Component {
      * @param direction the direction that the player last walked in.
      */
     private void setDirection(Vector2 direction) {
-        System.out.println("changed");
         this.directionMove = direction.cpy();
 
     }
-
-
-
 
 
     /**
@@ -133,6 +129,9 @@ public class PlayerMeleeAttackComponent extends Component {
      *              with
      */
     private void onEnemyClose(Fixture me, Fixture other) {
+        System.out.println("enemy coliding");
+        System.out.println(me);
+        System.out.println("different fixture : " + fixture);
 
         // By default, should only try detect NPC layers only
         if (!PhysicsLayer.contains(targetLayer, other.getFilterData().categoryBits)) {
@@ -150,9 +149,6 @@ public class PlayerMeleeAttackComponent extends Component {
         // enemy within range and player clicked melee attack button
         if (closeToAttack && meleeAttackClicked && targetStats != null) {
             targetStats.hit(playerCombatStats);
-            System.out.println("Enemy Hit");
-            System.out.println(me);
-
 
             // freezes enemy - will need to be replaced to despawn enemy entity
             if (targetStats.isDead()) {
@@ -282,15 +278,29 @@ public class PlayerMeleeAttackComponent extends Component {
         return fixture.getFilterData().categoryBits;
     }
 
-
     @Override
     public void dispose() {
         super.dispose();
+        System.out.println("Destroy fixture now =====");
+        System.out.println(fixture);
+//        System.out.println(fixture.getUserData());
         Body physBody = entity.getComponent(PhysicsComponent.class).getBody();
+        System.out.println("SOMETHING HEREEEEE" + physBody.getFixtureList().size);
         if (physBody.getFixtureList().contains(fixture, true)) {
-            physBody.destroyFixture(fixture);
-        }
+//            System.out.println("FIXTURE BEING DESTROYEEEEEEEEEEEEED");
+//            physBody.destroyFixture(fixture);
 
+            int toDestroy = physBody.getFixtureList().indexOf(fixture, true);
+            physBody.getFixtureList().removeIndex(toDestroy);
+            System.out.println("INDEX TO DESTROY : " + toDestroy);
+            System.out.println("fixture to destroy " + toDestroy);
+//            physBody.destroyFixture(toDestroy);
+        }
+        System.out.println("SOMETHING HEREEEEE??????" + physBody.getFixtureList().size);
+
+        System.out.println("NULL HERE PLEASE");
+        System.out.println(fixture);
+//        System.out.println(fixture.getShape());
         fixtureDef.shape = null;
     }
 
@@ -314,17 +324,17 @@ public class PlayerMeleeAttackComponent extends Component {
         }
 
         else if (directionMove.epsilonEquals(Vector2Utils.DOWN)){
-            System.out.println("UP");
+            System.out.println("DOWN");
             bbox.setAsBox(center.x * 2, center.y*(float)0.5, center.add( 0 , (float)-0.7), 0f);
         }
 
         else if (directionMove.epsilonEquals(Vector2Utils.LEFT)){
-            System.out.println("UP");
+            System.out.println("LEFT");
             bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float)-0.7 , 0), 0f);
         }
 
         else if (directionMove.epsilonEquals(Vector2Utils.RIGHT)){
-            System.out.println("UP");
+            System.out.println("RIGHT");
             bbox.setAsBox(center.x * (float)0.5, center.y*2, center.add( (float) 0.7 , 0), 0f);
         }
 

--- a/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/player/PlayerMeleeAttackComponent.java
@@ -39,6 +39,7 @@ public class PlayerMeleeAttackComponent extends Component {
 
     public PlayerMeleeAttackComponent() {
         fixtureDef = new FixtureDef();
+        directionMove = new Vector2((float)0.0,(float)0.0);
 
     }
 


### PR DESCRIPTION
Implementation of new directional melee attack instead of area-based attack. We didn't plan on getting this in for Sprint 1 but we had a breakthrough last night and eleminated all remaining bugs and issues. Completely changes the PlayerMeleeAttackComponent but that is all it should touch and affect. 
Also fixes the melee attack proximity bug observed in https://github.com/UQdeco2800/2021-studio-6/issues/45