### PR TITLE
Bullet collision with safehouse teleport bug

### DIFF
--- a/source/core/src/main/com/deco2800/game/components/TouchTeleportComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/TouchTeleportComponent.java
@@ -39,7 +39,6 @@ public class TouchTeleportComponent extends Component {
         if (PhysicsLayer.contains(targetLayer, other.getFilterData().categoryBits)) {
             // Try to teleport entity
             MainGameScreen.changeLevel();
-            System.out.println("Touched Safehouse");
         }
 
 

--- a/source/core/src/main/com/deco2800/game/components/TouchTeleportComponent.java
+++ b/source/core/src/main/com/deco2800/game/components/TouchTeleportComponent.java
@@ -36,13 +36,12 @@ public class TouchTeleportComponent extends Component {
             return;
         }
 
-        if (!PhysicsLayer.contains(targetLayer, other.getFilterData().categoryBits)) {
-            // Doesn't match our target layer, ignore
-            return;
+        if (PhysicsLayer.contains(targetLayer, other.getFilterData().categoryBits)) {
+            // Try to teleport entity
+            MainGameScreen.changeLevel();
+            System.out.println("Touched Safehouse");
         }
 
-        // Try to teleport entity
-        MainGameScreen.changeLevel();
-        System.out.println("Touched Safehouse");
+
     }
 }

--- a/source/core/src/main/com/deco2800/game/components/npc/BulletCollider.java
+++ b/source/core/src/main/com/deco2800/game/components/npc/BulletCollider.java
@@ -25,9 +25,10 @@ public class BulletCollider extends Component {
      * @param target the target to collide with
      * @param gameArea reference to the game area (used to spawn entity)
      */
-    public BulletCollider(Entity target, GameArea gameArea) {
+    public BulletCollider(Entity target, GameArea gameArea, short targetLayer) {
         this.target = target;
         this.gameArea = gameArea;
+        this.targetLayer = targetLayer;
     }
 
     @Override
@@ -35,7 +36,7 @@ public class BulletCollider extends Component {
         super.create();
         entity.getEvents().addListener("collisionStart", this::collide);
         this.hitboxComponent = entity.getComponent(HitboxComponent.class);
-        this.targetLayer = this.hitboxComponent.getLayer();
+
     }
 
     /**

--- a/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
+++ b/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
@@ -46,10 +46,10 @@ public class EnemyBulletFactory {
                 .addComponent(new PhysicsComponent())
                 .addComponent(new PhysicsMovementComponent(new Vector2(3, 3)))
                 .addComponent(new ColliderComponent())
-                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.PLAYER))
+                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.NPC))
                 .addComponent(new CombatStatsComponent(1, 2))
                 .addComponent(new TouchAttackComponent(PhysicsLayer.PLAYER, 0.2f))
-                .addComponent(new BulletCollider(target, gameArea));
+                .addComponent(new BulletCollider(target, gameArea, PhysicsLayer.PLAYER));
         bullet.setScale(0.8f, 0.8f);
         //centers the bullet to the source
         bullet.setPosition(

--- a/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
+++ b/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
@@ -46,7 +46,7 @@ public class EnemyBulletFactory {
                 .addComponent(new PhysicsComponent())
                 .addComponent(new PhysicsMovementComponent(new Vector2(3, 3)))
                 .addComponent(new ColliderComponent())
-                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.NPC))
+                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.OBSTACLE))
                 .addComponent(new CombatStatsComponent(1, 2))
                 .addComponent(new TouchAttackComponent(PhysicsLayer.PLAYER, 0.2f))
                 .addComponent(new BulletCollider(target, gameArea, PhysicsLayer.PLAYER));


### PR DESCRIPTION
This bug is when enemy bullet collides with the safehouse it spawns the player into the safehouse, This issue was caused by the hitbox layer on the bullet being set to the player layer, the safehouse would check all collisions on the player layer and since the bullet was on this layer it would 'collide' and teleport the player. Slight changes to how collision is handled on the enemy bullets