### PR TITLE
changed physics layer for enemy bullet

### DIFF
--- a/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
+++ b/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
@@ -46,7 +46,7 @@ public class EnemyBulletFactory {
                 .addComponent(new PhysicsComponent())
                 .addComponent(new PhysicsMovementComponent(new Vector2(3, 3)))
                 .addComponent(new ColliderComponent())
-                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.NONE))
+                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.ENEMYBULLET))
                 .addComponent(new CombatStatsComponent(1, 2))
                 .addComponent(new TouchAttackComponent(PhysicsLayer.PLAYER, 0.2f))
                 .addComponent(new BulletCollider(target, gameArea, PhysicsLayer.PLAYER));

--- a/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
+++ b/source/core/src/main/com/deco2800/game/entities/factories/EnemyBulletFactory.java
@@ -46,7 +46,7 @@ public class EnemyBulletFactory {
                 .addComponent(new PhysicsComponent())
                 .addComponent(new PhysicsMovementComponent(new Vector2(3, 3)))
                 .addComponent(new ColliderComponent())
-                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.OBSTACLE))
+                .addComponent(new HitboxComponent().setLayer(PhysicsLayer.NONE))
                 .addComponent(new CombatStatsComponent(1, 2))
                 .addComponent(new TouchAttackComponent(PhysicsLayer.PLAYER, 0.2f))
                 .addComponent(new BulletCollider(target, gameArea, PhysicsLayer.PLAYER));

--- a/source/core/src/main/com/deco2800/game/physics/PhysicsLayer.java
+++ b/source/core/src/main/com/deco2800/game/physics/PhysicsLayer.java
@@ -16,6 +16,8 @@ public class PhysicsLayer {
   // Paraphernalia
   public static final short PARAPHERNALIA = (1 << 4);
 
+  public static final short ENEMYBULLET = (1 << 7);
+
   public static boolean contains(short filterBits, short layer) {
     return (filterBits & layer) != 0;
   }


### PR DESCRIPTION
#113, this fix changes the physics layer for enemy bullet, this will have to be changed again when we add boundaries for bullets so they can despawn when they leave the game area, but it should be cool for now :)